### PR TITLE
[STK-315] remove readiness probe

### DIFF
--- a/exposecontroller/templates/deployment.yaml
+++ b/exposecontroller/templates/deployment.yaml
@@ -27,13 +27,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: "{{ .Values.exposeController.image.name }}:{{ .Values.exposeController.image.tag }}"
-        imagePullPolicy: {{ .Values.exposeController.image.pullPolicy }}
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/restarteveryday
-          initialDelaySeconds: {{ .Values.exposeController.probes.readiness.initialDelaySeconds }}
+        imagePullPolicy: {{ .Values.exposeController.image.pullPolicy }}        
         livenessProbe:
           exec:
             command:

--- a/exposecontroller/values.yaml
+++ b/exposecontroller/values.yaml
@@ -10,8 +10,6 @@ exposeController:
   # false by default
 #  http: true
   probes:
-    readiness:
-      initialDelaySeconds: 86164
     liveness:
       initialDelaySeconds: 86164
   image:


### PR DESCRIPTION
Removing it as in liveness probe 
livenessProbe:
       exec:
            command:
            - cat
            - /tmp/restarteveryday
it is just trying to cat this file which will not be found so it will restart it 